### PR TITLE
Be able to run PVS-Studio in both the Cygwin ( https://www.cygwin.com…

### DIFF
--- a/PVS-Studio.cmake
+++ b/PVS-Studio.cmake
@@ -344,11 +344,15 @@ function (pvs_studio_add_target)
 
     set(PATHS)
 
-    if (CMAKE_HOST_WIN32)
-        # The registry value is only read when you do some cache operation on it.
-        # https://stackoverflow.com/questions/1762201/reading-registry-values-with-cmake
-        GET_FILENAME_COMPONENT(ROOT "[HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\ProgramVerificationSystems\\PVS-Studio;installDir]" ABSOLUTE CACHE)
-
+    if (CMAKE_HOST_WIN32 OR CYGWIN OR MSYS)
+        if(CMAKE_HOST_WIN32)
+          # The registry value is only read when you do some cache operation on it.
+          # https://stackoverflow.com/questions/1762201/reading-registry-values-with-cmake
+          GET_FILENAME_COMPONENT(ROOT "[HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\ProgramVerificationSystems\\PVS-Studio;installDir]" ABSOLUTE CACHE)
+		else()
+		  # for some reason, set(ROOT "$ENV{${ROOT}}/PVS-Studio") did not work
+		  set(ROOT "$ENV{ProgramFiles\(x86\)}/PVS-Studio")
+        endif()		
         if (EXISTS "${ROOT}")
            set(PATHS "${ROOT}")
         else()


### PR DESCRIPTION
…/ ) and MSYS2 ( https://www.msys2.org/ ) version of CMake.  Those versions do NOT define CMAKE_HOST_WIN32 because the binaries that are generated are SPECIFICALLY for those environments even though they both run in Windows.